### PR TITLE
Replace deprected commands in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - id: set-matrix
         run: |
           matrix=$(cat versions.json | jq -c .)
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
   test:
     name: Test
     needs: generate-matrix

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - id: set-xcode-version
         run: |
           xcode_version=$(cat versions.json | jq -rc '.xcode_version | max')
-          echo "::set-output name=xcode-version::$xcode_version"
+          echo "xcode-version=$xcode_version" >> $GITHUB_OUTPUT
       - name: Build and zip
         env:
           DEVELOPER_DIR: /Applications/Xcode_${{ steps.set-xcode-version.outputs.xcode-version }}.app/Contents/Developer


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
