### PR TITLE
Remove `buildconfigswift-lastrun`

### DIFF
--- a/Demo/project.yml
+++ b/Demo/project.yml
@@ -95,8 +95,6 @@ targets:
           else
             xcrun -sdk macosx swift run --package-path "${SRCROOT}/.." buildconfigswift -o ${SRCROOT}/Libs/BuildConfig_swift -e $ENVIRONMENT ${SRCROOT}/Resources/Config # For Development
           fi
-        inputFiles:
-          - $(TEMP_DIR)/buildconfigswift-lastrun
         outputFiles:
           - $(SRCROOT)/Libs/BuildConfig_swift/BuildConfig.generated.swift
         basedOnDependencyAnalysis: false

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Version](http://img.shields.io/cocoapods/v/BuildConfig.swift.svg?style=flat)](http://cocoapods.org/pods/BuildConfig.swift)
 [![Platform](http://img.shields.io/cocoapods/p/BuildConfig.swift.svg?style=flat)](http://cocoapods.org/pods/BuildConfig.swift)
 [![GitHub release](https://img.shields.io/github/release/417-72KI/BuildConfig.swift/all.svg)](https://github.com/417-72KI/BuildConfig.swift/releases)
-[![Swift Package Manager](https://img.shields.io/badge/Swift%20Package%20Manager-5.5-brightgreen.svg)](https://github.com/apple/swift-package-manager)
+[![Swift Package Manager](https://img.shields.io/badge/Swift%20Package%20Manager-5.6-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 [![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/417-72KI/BuildConfig.swift/master/LICENSE.md)
 
 BuildConfig.swift is a tool to generate configuration files by merging _yamls_ or _jsons_.
@@ -83,7 +83,6 @@ You can replace `"$SRCROOT/$PROJECT/Resources/Config"` to the relative path from
 
 Also, you can add `-o` option with output path to specify where `BuildConfig.plist` and `BuildConfig.generated.swift` will be created.
 
-- Add `$(TEMP_DIR)/buildconfigswift-lastrun` into `Input Files` in above `Run script` build phase.
 - Add `$(SRCROOT)/BuildConfig.generated.swift` into `Output Files` in above `Run script` build phase.
     - If you set a path to output generated files by `-o` option, you have to change `Output Files` to it's path.
 

--- a/Sources/Common/Console.swift
+++ b/Sources/Common/Console.swift
@@ -2,11 +2,11 @@ import Darwin
 import Foundation
 
 public func dumpInfo(_ message: @autoclosure () -> String) {
-    fputs("\(tag)[Info] \(message())\n", stdout)
+    fputs("\(tag) \(message())\n", stdout)
 }
 
 public func dumpError(_ message: @autoclosure () -> String) {
-    fputs("\(tag)[Error] \(message())\n", stderr)
+    fputs("error: \(tag) \(message())\n", stderr)
 }
 
 public func dumpError(_ error: @autoclosure () -> Error) {
@@ -14,7 +14,7 @@ public func dumpError(_ error: @autoclosure () -> Error) {
 }
 
 public func dumpWarn(_ message: @autoclosure () -> String) {
-    fputs("\(tag)[Warning] \(message())\n", stderr)
+    fputs("warning: \(tag) \(message())\n", stderr)
 }
 
 private var tag: String {

--- a/Sources/Common/Constants.swift
+++ b/Sources/Common/Constants.swift
@@ -1,6 +1,6 @@
 public enum Constants {
     public static let generatedSwiftFileName = "BuildConfig.generated.swift"
 
-    @available(*, deprecated, message: "Will be removed soon.")
+    // TODO: Will be removed soon.
     public static let lastRunFileName = "buildconfigswift-lastrun"
 }

--- a/Sources/Common/Constants.swift
+++ b/Sources/Common/Constants.swift
@@ -1,6 +1,3 @@
 public enum Constants {
     public static let generatedSwiftFileName = "BuildConfig.generated.swift"
-
-    // TODO: Will be removed soon.
-    public static let lastRunFileName = "buildconfigswift-lastrun"
 }

--- a/Sources/Common/Constants.swift
+++ b/Sources/Common/Constants.swift
@@ -1,5 +1,6 @@
 public enum Constants {
     public static let generatedSwiftFileName = "BuildConfig.generated.swift"
 
+    @available(*, deprecated, message: "Will be removed soon.")
     public static let lastRunFileName = "buildconfigswift-lastrun"
 }

--- a/Sources/Core/Core.swift
+++ b/Sources/Core/Core.swift
@@ -78,6 +78,7 @@ extension Core {
     }
 }
 
+@available(*, deprecated, message: "Will be removed soon.")
 extension Core {
     func createLastRunFile() {
         let lastRunFile = tempDirectoryPath + Constants.lastRunFileName

--- a/Sources/Core/Core.swift
+++ b/Sources/Core/Core.swift
@@ -31,7 +31,14 @@ public struct Core {
     public func execute() throws {
         defer { createLastRunFile() }
 
-        try validate()
+        do {
+            try validate()
+        } catch let error as ValidationError {
+            dumpError("Validation error:")
+            error.errors
+                .forEach { dumpError($0) }
+            return
+        }
 
         let data = try Parser(directoryPath: srcDirectoryPath)
             .run(environment: environment)
@@ -53,8 +60,8 @@ extension Core {
         }
 
         let scriptInputFiles = self.scriptInputFiles.map { $0.lastComponent }
-        if !scriptInputFiles.contains(Constants.lastRunFileName) {
-            errors.append("Build phase Input Files does not contain `$(TEMP_DIR)/\(Constants.lastRunFileName)`")
+        if scriptInputFiles.contains(Constants.lastRunFileName) {
+            dumpWarn("`$(TEMP_DIR)/\(Constants.lastRunFileName)` is no longer needed in Build phase Input Files. Remove it from `Input Files` and uncheck `Based on dependency analysis` instead.")
         }
 
         let scriptOutputFiles = self.scriptOutputFiles.map { $0.lastComponent }

--- a/Sources/Core/Core.swift
+++ b/Sources/Core/Core.swift
@@ -29,8 +29,6 @@ public struct Core {
     }
 
     public func execute() throws {
-        defer { createLastRunFile() }
-
         do {
             try validate()
         } catch let error as ValidationError {
@@ -82,18 +80,5 @@ extension Core {
         }
         try content.write(to: dest.url, atomically: true, encoding: .utf8)
         dumpInfo("create \(dest)")
-    }
-}
-
-@available(*, deprecated, message: "Will be removed soon.")
-extension Core {
-    func createLastRunFile() {
-        let lastRunFile = tempDirectoryPath + Constants.lastRunFileName
-        do {
-            try "\(Date().timeIntervalSince1970)\n"
-                .write(to: lastRunFile.url, atomically: true, encoding: .utf8)
-        } catch {
-            dumpWarn("Failed to write out to '\(lastRunFile)', this might cause Xcode to not run the build phase for BuildConfig.swift: \(error)")
-        }
     }
 }

--- a/Sources/Core/Core.swift
+++ b/Sources/Core/Core.swift
@@ -58,8 +58,10 @@ extension Core {
         }
 
         let scriptInputFiles = self.scriptInputFiles.map { $0.lastComponent }
-        if scriptInputFiles.contains(Constants.lastRunFileName) {
-            dumpWarn("`$(TEMP_DIR)/\(Constants.lastRunFileName)` is no longer needed in Build phase Input Files. Remove it from `Input Files` and uncheck `Based on dependency analysis` instead.")
+
+        let lastRunFileName = "buildconfigswift-lastrun"
+        if scriptInputFiles.contains(lastRunFileName) {
+            dumpWarn("`$(TEMP_DIR)/\(lastRunFileName)` is no longer needed in Build phase Input Files and no more updated. Remove it from `Input Files` and uncheck `Based on dependency analysis` instead.")
         }
 
         let scriptOutputFiles = self.scriptOutputFiles.map { $0.lastComponent }


### PR DESCRIPTION
- remove lastrun file from demo app config
- deprecate lastrun file
- fix console to dump warnings/errors on Xcode Issue Navigator
- warn if lastrun file still exists on `Input files`
- remove lastrun file create function
