### PR TITLE
Use JSON instead of PropertyList as a raw data

### DIFF
--- a/Sources/Generator/CodeGenerator/CodeGenerator.swift
+++ b/Sources/Generator/CodeGenerator/CodeGenerator.swift
@@ -49,8 +49,9 @@ extension CodeGenerator {
         if asBinary {
             rawDataString = data.base64EncodedString()
         } else {
-            let propertyList = try PropertyListSerialization.propertyList(from: data, format: nil)
-            let rawData = try PropertyListSerialization.data(fromPropertyList: propertyList, format: .xml, options: 0)
+            let json = try JSONSerialization.jsonObject(with: data)
+            let rawData = try JSONSerialization.data(withJSONObject: json, 
+                                                     options: [.sortedKeys, .prettyPrinted])
             rawDataString = String(data: rawData, encoding: .utf8) ?? ""
         }
         return try render(with: .rawData(asBinary: asBinary), dictionary: ["rawData": rawDataString])

--- a/Sources/Generator/CodeGenerator/CodeGenerator.swift
+++ b/Sources/Generator/CodeGenerator/CodeGenerator.swift
@@ -50,8 +50,10 @@ extension CodeGenerator {
             rawDataString = data.base64EncodedString()
         } else {
             let json = try JSONSerialization.jsonObject(with: data)
-            let rawData = try JSONSerialization.data(withJSONObject: json, 
-                                                     options: [.sortedKeys, .prettyPrinted])
+            let rawData = try JSONSerialization.data(
+                withJSONObject: json,
+                options: [.sortedKeys, .prettyPrinted]
+            )
             rawDataString = String(data: rawData, encoding: .utf8) ?? ""
         }
         return try render(with: .rawData(asBinary: asBinary), dictionary: ["rawData": rawDataString])

--- a/Sources/Generator/CodeGenerator/Template.swift
+++ b/Sources/Generator/CodeGenerator/Template.swift
@@ -58,7 +58,7 @@ extension Template {
 
                 static func load(from data: Data) -> BuildConfig {
                     do {
-                        return try PropertyListDecoder().decode(BuildConfig.self, from: data)
+                        return try JSONDecoder().decode(BuildConfig.self, from: data)
                     } catch {
                         fatalError("Invalid data (\\(String(data: data, encoding: .utf8) ?? ""). cause: \\(error)")
                     }

--- a/Sources/Generator/Generator.swift
+++ b/Sources/Generator/Generator.swift
@@ -1,6 +1,5 @@
-import struct Foundation.Data
-import class Foundation.PropertyListSerialization
 import Common
+import Foundation
 import PathKit
 
 public struct Generator {
@@ -13,10 +12,9 @@ public struct Generator {
 
 public extension Generator {
     func run() throws -> String {
-        guard let content = try PropertyListSerialization.propertyList(
-            from: data,
-            options: [],
-            format: nil
+        guard let content = try JSONSerialization.jsonObject(
+            with: data,
+            options: []
         ) as? [AnyHashable: Any] else { throw GeneratorError.invalidData }
         guard let parsed = Parser(content: content).run() else { throw GeneratorError.parseFailed(content) }
         return try CodeGenerator(content: parsed, data: data).run()

--- a/Sources/Generator/Generator.swift
+++ b/Sources/Generator/Generator.swift
@@ -12,7 +12,7 @@ public struct Generator {
 
 public extension Generator {
     func run() throws -> String {
-        guard let content = try JSONSerialization.jsonObject(
+        guard let content = try? JSONSerialization.jsonObject(
             with: data,
             options: []
         ) as? [AnyHashable: Any] else { throw GeneratorError.invalidData }

--- a/Sources/Parser/Parser.swift
+++ b/Sources/Parser/Parser.swift
@@ -28,10 +28,9 @@ public extension Parser {
         let defaultData = try parse(files: otherFiles, skipInvalidFile: skipInvalidFile)
             .reduce(AnyParsable()) { $0 + $1 }
         let result = defaultData + environmentData
-        return try PropertyListSerialization.data(
-            fromPropertyList: result.rawValue,
-            format: .binary,
-            options: 0
+        return try JSONSerialization.data(
+            withJSONObject: result.rawValue,
+            options: []
         )
     }
 }

--- a/Tests/GeneratorTests/GeneratorTests.swift
+++ b/Tests/GeneratorTests/GeneratorTests.swift
@@ -26,7 +26,7 @@ final class GeneratorTests: XCTestCase {
                 "isDebug": false,
                 "pi": 3.14159265358979
             ] as [AnyHashable: Any]
-            let data = try PropertyListSerialization.data(fromPropertyList: content, format: .binary, options: 0)
+            let data = try JSONSerialization.data(withJSONObject: content, options: .sortedKeys)
             try context("success") {
                 let file = try XCTUnwrap(File(path: path + "Testcase.swift"))
                 let contents = file.contents
@@ -47,8 +47,10 @@ final class GeneratorTests: XCTestCase {
 
                 try context("rawData") {
                     let (actual, expected) = try XCTUnwrap(zipped.suffix(1).first)
-                    let actualDic = try PropertyListSerialization.propertyList(from: try XCTUnwrap(Data(base64Encoded: String(actual.dropFirst(43).dropLast(3)))), format: nil) as? NSDictionary
-                    let expectedDic = try PropertyListSerialization.propertyList(from: try XCTUnwrap(Data(base64Encoded: String(expected.dropFirst(43).dropLast(3)))), format: nil) as? NSDictionary
+                    let base64String = (actual: String(actual.dropFirst(43).dropLast(3)), expected: String(expected.dropFirst(43).dropLast(3)))
+                    XCTAssertEqual(base64String.actual, base64String.expected)
+                    let actualDic = try JSONSerialization.jsonObject(with: try XCTUnwrap(Data(base64Encoded: base64String.actual))) as? NSDictionary
+                    let expectedDic = try JSONSerialization.jsonObject(with: try XCTUnwrap(Data(base64Encoded: base64String.expected))) as? NSDictionary
                     XCTAssertEqual(actualDic, expectedDic, diff(between: actualDic, and: expectedDic))
                 }
             }
@@ -59,7 +61,7 @@ final class GeneratorTests: XCTestCase {
                 "a_struct": [:],
                 "b_struct": ["hoge": "fuga"]
                 ] as [AnyHashable: Any]
-            let data = try PropertyListSerialization.data(fromPropertyList: content, format: .binary, options: 0)
+            let data = try JSONSerialization.data(withJSONObject: content, options: .sortedKeys)
             try context("success") {
                 let file = try XCTUnwrap(File(path: path + "EmptyNestCase.swift"))
                 let contents = file.contents
@@ -81,8 +83,10 @@ final class GeneratorTests: XCTestCase {
 
                 try context("rawData") {
                     let (actual, expected) = try XCTUnwrap(zipped.suffix(1).first)
-                    let actualDic = try PropertyListSerialization.propertyList(from: try XCTUnwrap(Data(base64Encoded: String(actual.dropFirst(43).dropLast(3)))), format: nil) as? NSDictionary
-                    let expectedDic = try PropertyListSerialization.propertyList(from: try XCTUnwrap(Data(base64Encoded: String(expected.dropFirst(43).dropLast(3)))), format: nil) as? NSDictionary
+                    let base64String = (actual: String(actual.dropFirst(43).dropLast(3)), expected: String(expected.dropFirst(43).dropLast(3)))
+                    XCTAssertEqual(base64String.actual, base64String.expected)
+                    let actualDic = try JSONSerialization.jsonObject(with: try XCTUnwrap(Data(base64Encoded: base64String.actual))) as? NSDictionary
+                    let expectedDic = try JSONSerialization.jsonObject(with: try XCTUnwrap(Data(base64Encoded: base64String.expected))) as? NSDictionary
                     XCTAssertEqual(actualDic, expectedDic, diff(between: actualDic, and: expectedDic))
                 }
             }
@@ -90,7 +94,7 @@ final class GeneratorTests: XCTestCase {
 
         try context("empty data") {
             let content = [:] as [AnyHashable: Any]
-            let data = try PropertyListSerialization.data(fromPropertyList: content, format: .binary, options: 0)
+            let data = try JSONSerialization.data(withJSONObject: content, options: .sortedKeys)
             try context("success") {
                 let file = try XCTUnwrap(File(path: path + "EmptyCase.swift"))
                 let contents = file.contents
@@ -103,7 +107,7 @@ final class GeneratorTests: XCTestCase {
             let data = "string".data(using: .utf8)!
             try context("fail") {
                 XCTAssertThrowsError(try Generator(data: data).run()) {
-                    guard case .invalidData = $0 as? GeneratorError else {
+                    guard case GeneratorError.invalidData = $0 else {
                         XCTFail($0.localizedDescription)
                         return
                     }

--- a/Tests/GeneratorTests/Resources/EmptyCase.swift
+++ b/Tests/GeneratorTests/Resources/EmptyCase.swift
@@ -27,11 +27,11 @@ extension BuildConfig {
 
     static func load(from data: Data) -> BuildConfig {
         do {
-            return try PropertyListDecoder().decode(BuildConfig.self, from: data)
+            return try JSONDecoder().decode(BuildConfig.self, from: data)
         } catch {
             fatalError("Invalid data (\(String(data: data, encoding: .utf8) ?? ""). cause: \(error)")
         }
     }
 }
 
-private let rawData = Data(base64Encoded: "YnBsaXN0MDDQCAAAAAAAAAEBAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAJ")!
+private let rawData = Data(base64Encoded: "e30=")!

--- a/Tests/GeneratorTests/Resources/EmptyNestCase.swift
+++ b/Tests/GeneratorTests/Resources/EmptyNestCase.swift
@@ -35,7 +35,7 @@ extension BuildConfig {
 
     static func load(from data: Data) -> BuildConfig {
         do {
-            return try PropertyListDecoder().decode(BuildConfig.self, from: data)
+            return try JSONDecoder().decode(BuildConfig.self, from: data)
         } catch {
             fatalError("Invalid data (\(String(data: data, encoding: .utf8) ?? ""). cause: \(error)")
         }
@@ -57,4 +57,4 @@ extension BuildConfig {
     }
 }
 
-private let rawData = Data(base64Encoded: "YnBsaXN0MDDSAQIDBlhiX3N0cnVjdFhhX3N0cnVjdNEEBVRob2dlVGZ1Z2HQCA0WHyInLAAAAAAAAAEBAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAt")!
+private let rawData = Data(base64Encoded: "eyJhX3N0cnVjdCI6e30sImJfc3RydWN0Ijp7ImhvZ2UiOiJmdWdhIn19")!

--- a/Tests/GeneratorTests/Resources/Testcase.swift
+++ b/Tests/GeneratorTests/Resources/Testcase.swift
@@ -45,7 +45,7 @@ extension BuildConfig {
 
     static func load(from data: Data) -> BuildConfig {
         do {
-            return try PropertyListDecoder().decode(BuildConfig.self, from: data)
+            return try JSONDecoder().decode(BuildConfig.self, from: data)
         } catch {
             fatalError("Invalid data (\(String(data: data, encoding: .utf8) ?? ""). cause: \(error)")
         }
@@ -96,4 +96,4 @@ extension BuildConfig {
     }
 }
 
-private let rawData = Data(base64Encoded: "YnBsaXN0MDDXAQIDBAUGBwgJCg4YGxxVdG9rZW5ScGlXbGljZW5zZVNBUElUYm9vdFtlbnZpcm9ubWVudFdpc0RlYnVnEgAB4kAjQAkh+1RELRGjCwwNVFlhbWxXUGF0aEtpdF8QD1N0ZW5jaWxTd2lmdEtpdNIPEBEXVHBhdGhWZG9tYWlu0RITVWxvZ2lu0g8UFRZWbWV0aG9kVi9sb2dpblRQT1NUXxASaHR0cDovLzE5Mi4xNjguMC4x0RkaV21lc3NhZ2VdSGVsbG8sIFdvcmxkIVtkZXZlbG9wbWVudAgIFx0gKCwxPUVKU1dcZHZ7gIeKkJWco6i9wMjW4gAAAAAAAAEBAAAAAAAAAB0AAAAAAAAAAAAAAAAAAADj")!
+private let rawData = Data(base64Encoded: "eyJBUEkiOnsiZG9tYWluIjoiaHR0cDpcL1wvMTkyLjE2OC4wLjEiLCJwYXRoIjp7ImxvZ2luIjp7Im1ldGhvZCI6IlBPU1QiLCJwYXRoIjoiXC9sb2dpbiJ9fX0sImJvb3QiOnsibWVzc2FnZSI6IkhlbGxvLCBXb3JsZCEifSwiZW52aXJvbm1lbnQiOiJkZXZlbG9wbWVudCIsImlzRGVidWciOmZhbHNlLCJsaWNlbnNlIjpbIllhbWwiLCJQYXRoS2l0IiwiU3RlbmNpbFN3aWZ0S2l0Il0sInBpIjozLjE0MTU5MjY1MzU4OTc5LCJ0b2tlbiI6MTIzNDU2fQ==")!

--- a/Tests/ParserTests/FileParserTests.swift
+++ b/Tests/ParserTests/FileParserTests.swift
@@ -19,7 +19,8 @@ final class FileParserTests: XCTestCase {
                             "login": TestContent.API.Path(method: .post, path: "/login"),
                             "getList": TestContent.API.Path(method: .get, path: "/list")
                         ],
-                        timeout: 11.5
+                        timeout: 11.5,
+                        apiVersion: 1
                     ),
                     count: 0,
                     isDebug: true
@@ -35,6 +36,9 @@ final class FileParserTests: XCTestCase {
 
                 let timeout = try XCTUnwrap(api["timeout"]?.value as? Double)
                 XCTAssertEqual(timeout, 11.5, accuracy: 0.1)
+
+                let apiVersion = try XCTUnwrap(api["api_version"]?.value as? Int)
+                XCTAssertEqual(1, apiVersion)
 
                 let count = try XCTUnwrap(root["count"]?.value as? Int)
                 XCTAssertEqual(count, 0)
@@ -57,7 +61,8 @@ final class FileParserTests: XCTestCase {
                             "login": TestContent.API.Path(method: .post, path: "/login"),
                             "getList": TestContent.API.Path(method: .get, path: "/list")
                         ],
-                        timeout: 10.5
+                        timeout: 10.5,
+                        apiVersion: 1
                     ),
                     count: 0,
                     isDebug: true
@@ -73,7 +78,10 @@ final class FileParserTests: XCTestCase {
                 
                 let timeout = try XCTUnwrap(api["timeout"]?.value as? Double)
                 XCTAssertEqual(timeout, 10.5, accuracy: 0.1)
-                
+
+                let apiVersion = try XCTUnwrap(api["api_version"]?.value as? Int)
+                XCTAssertEqual(1, apiVersion)
+
                 let count = try XCTUnwrap(root["count"]?.value as? Int)
                 XCTAssertEqual(count, 0)
                 
@@ -93,6 +101,7 @@ private struct TestContent: Codable, Equatable {
         let domain: URL
         let api: [String: Path]
         let timeout: Double
+        let apiVersion: Int
 
         struct Path: Codable, Equatable {
             let method: Method
@@ -103,11 +112,13 @@ private struct TestContent: Codable, Equatable {
             case get = "GET"
             case post = "POST"
         }
+
+        enum CodingKeys: String, CodingKey {
+            case domain, api, timeout, apiVersion = "api_version"
+        }
     }
 
     enum CodingKeys: String, CodingKey {
-        case api = "API"
-        case count
-        case isDebug = "is_debug"
+        case api = "API", count, isDebug = "is_debug"
     }
 }

--- a/Tests/ParserTests/Resources/test.json
+++ b/Tests/ParserTests/Resources/test.json
@@ -11,7 +11,8 @@
                 "path": "/list"
             }
         },
-        "timeout": 10.5
+        "timeout": 10.5,
+        "api_version": 1
     },
     "count": 0,
     "is_debug": true

--- a/Tests/ParserTests/Resources/test.yaml
+++ b/Tests/ParserTests/Resources/test.yaml
@@ -8,5 +8,6 @@ API:
       method: GET
       path: /list
   timeout: 11.5
+  api_version: 1
 count: 0
 is_debug: true


### PR DESCRIPTION
Since in PropertyList, any numbers(e.g. `Int`, `Double`) or bools are stored as `__NSCFNumber` and difficult to identify, it causes a bug(#63).
JSON can identify that it is bool or number.