### PR TITLE
Fix deployment target for CocoaPods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,10 @@ jobs:
           cache-name: swiftpm
         with:
           path: .build
-          key: ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
+          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-
             ${{ runner.os }}-${{ github.job }}-
             ${{ runner.os }}-
       - name: Disable SwiftLint Plugin
@@ -73,9 +74,10 @@ jobs:
           path: |
             Demo/.build
             Demo/Tools/.build
-          key: ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
+          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-
             ${{ runner.os }}-${{ github.job }}-
             ${{ runner.os }}-
       - name: Cache DerivedData
@@ -84,9 +86,10 @@ jobs:
           cache-name: derived-data
         with:
           path: Demo/DerivedData
-          key: ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
+          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-
             ${{ runner.os }}-${{ github.job }}-
             ${{ runner.os }}-
       - name: Disable SwiftLint Plugin
@@ -118,9 +121,10 @@ jobs:
           path: |
             DemoWithPackage/.build
             DemoWithPackage/Tools/.build
-          key: ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
+          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-
             ${{ runner.os }}-${{ github.job }}-
             ${{ runner.os }}-
       - name: Cache DerivedData
@@ -129,9 +133,10 @@ jobs:
           cache-name: derived-data
         with:
           path: DemoWithPackage/DerivedData
-          key: ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
+          key: ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-${{ hashFiles('**/Package.swift') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ github.job }}-${{ matrix.xcode_version }}-
             ${{ runner.os }}-${{ github.job }}-
             ${{ runner.os }}-
       - name: Disable SwiftLint Plugin

--- a/BuildConfig.swift.podspec
+++ b/BuildConfig.swift.podspec
@@ -13,10 +13,10 @@ Pod::Spec.new do |s|
   s.author             = { "417.72KI" => "417.72ki@gmail.com" }
   s.social_media_url   = "http://twitter.com/417_72ki"
 
-  s.ios.deployment_target = "10.0"
-  s.osx.deployment_target = "10.9"
-  s.watchos.deployment_target = "3.0"
-  s.tvos.deployment_target = "10.0"
+  s.ios.deployment_target = "15.0"
+  s.osx.deployment_target = "12.0"
+  s.watchos.deployment_target = "8.0"
+  s.tvos.deployment_target = "15.0"
 
   s.requires_arc = true
   

--- a/DemoWithPackage/Sources/BuildConfigSwiftDemo/Repository/APIClient.swift
+++ b/DemoWithPackage/Sources/BuildConfigSwiftDemo/Repository/APIClient.swift
@@ -46,7 +46,7 @@ extension APIClient {
         return try decoder.decode(LoginResponse.self, from: data)
     }
 
-    @available(iOS 16.0, *)
+    @available(iOS 16.0, watchOS 9.0, tvOS 16.0, *)
     func search(_ text: String) async throws -> SearchResponse {
         let endpoint = endpoint(\.search)
         let url = host.appendingPathComponent(endpoint.path)


### PR DESCRIPTION
```sh
- NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.5.99. (in target 'BuildConfig.swift' from project 'Pods')
- NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.5.99. (in target 'Pods-App' from project 'Pods')
- NOTE  | [iOS] xcodebuild:  /var/folders/kq/c_q_38150nb0g900jl9xsb8h0000gn/T/CocoaPods-Lint-20240704-90127-kli01w-BuildConfig.swift/App.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.5.99. (in target 'App' from project 'App')
- ERROR | [OSX] xcodebuild: Returned an unsuccessful exit code. You can use `--verbose` for more information.
- NOTE  | xcodebuild:  note: Using codesigning identity override: 
- NOTE  | [OSX] xcodebuild:  clang: error: SDK does not contain 'libarclite' at the path '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_macosx.a'; try increasing the minimum deployment target
- NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.9, but the range of supported deployment target versions is 10.13 to 14.5.99. (in target 'BuildConfig.swift' from project 'Pods')
- NOTE  | [OSX] xcodebuild:  Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.9, but the range of supported deployment target versions is 10.13 to 14.5.99. (in target 'Pods-App' from project 'Pods')
- NOTE  | [OSX] xcodebuild:  /var/folders/kq/c_q_38150nb0g900jl9xsb8h0000gn/T/CocoaPods-Lint-20240704-90127-kli01w-BuildConfig.swift/App.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.9, but the range of supported deployment target versions is 10.13 to 14.5.99. (in target 'App' from project 'App')
- NOTE  | [watchOS] xcodebuild:  Pods.xcodeproj: warning: The watchOS Simulator deployment target 'WATCHOS_DEPLOYMENT_TARGET' is set to 3.0, but the range of supported deployment target versions is 4.0 to 10.5.99. (in target 'BuildConfig.swift' from project 'Pods')
- NOTE  | [watchOS] xcodebuild:  Pods.xcodeproj: warning: The watchOS Simulator deployment target 'WATCHOS_DEPLOYMENT_TARGET' is set to 3.0, but the range of supported deployment target versions is 4.0 to 10.5.99. (in target 'Pods-App' from project 'Pods')
- NOTE  | [watchOS] xcodebuild:  /var/folders/kq/c_q_38150nb0g900jl9xsb8h0000gn/T/CocoaPods-Lint-20240704-90127-kli01w-BuildConfig.swift/App.xcodeproj: warning: The watchOS Simulator deployment target 'WATCHOS_DEPLOYMENT_TARGET' is set to 3.0, but the range of supported deployment target versions is 4.0 to 10.5.99. (in target 'App' from project 'App')
- NOTE  | [tvOS] xcodebuild:  Pods.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.5.99. (in target 'BuildConfig.swift' from project 'Pods')
- NOTE  | [tvOS] xcodebuild:  Pods.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.5.99. (in target 'Pods-App' from project 'Pods')
- NOTE  | [tvOS] xcodebuild:  /var/folders/kq/c_q_38150nb0g900jl9xsb8h0000gn/T/CocoaPods-Lint-20240704-90127-kli01w-BuildConfig.swift/App.xcodeproj: warning: The tvOS Simulator deployment target 'TVOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 12.0 to 17.5.99. (in target 'App' from project 'App')
````